### PR TITLE
CT 152 Updated to show the chemical data upon scanning the qr code

### DIFF
--- a/frontend/app/(tabs)/scanQRCode.tsx
+++ b/frontend/app/(tabs)/scanQRCode.tsx
@@ -39,7 +39,7 @@ export default function ViewChemicals() {
           }
       } catch (error) {
           console.log  ('Error fetching chemical data:', error);
-          Alert.alert('Error', 'nvalid QR or Error fetching chemical data');
+          Alert.alert('Error', 'Invalid QR or Error fetching chemical data');
       } finally {
           setIsFetching(false);
       }

--- a/frontend/app/(tabs)/scanQRCode.tsx
+++ b/frontend/app/(tabs)/scanQRCode.tsx
@@ -1,14 +1,53 @@
 import React from 'react';
 import { useState } from 'react';
-import { View, Text, StyleSheet, Button, TouchableOpacity } from 'react-native';
+import { View, Text, StyleSheet, Button, TouchableOpacity, Alert} from 'react-native';
 import { CameraView, CameraType, useCameraPermissions} from 'expo-camera';
+import ChemicalDetails from '@/components/viewChemicalModals/ChemicalDetails';
+import * as WebBrowser from 'expo-web-browser';
+import { useRouter } from 'expo-router';
 
 export default function ViewChemicals() {
-  
   const [facing, setFacing] = useState<CameraType>('back');
   const [permission, requestPermission] = useCameraPermissions();
-  let data = "";
-
+  const [scannedData, setScannedData] = useState<string | null>(null);
+  const [selectedChemical, setSelectedChemical] = useState(null);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [isSDSBottomSheetOpen, setIsSDSBottomSheetOpen] = useState(false);
+  const [isFetching, setIsFetching] = useState(false);
+  const router = useRouter();
+  const API_URL = `http://${process.env.EXPO_PUBLIC_API_URL}`;
+  const viewPdf = async (pdfUrl: string) => {
+      console.log('Opening PDF:', pdfUrl);
+      await WebBrowser.openBrowserAsync(pdfUrl);
+  };
+  const toggleSDSBottomSheet = () => {
+      setIsSDSBottomSheetOpen(!isSDSBottomSheetOpen);
+      viewPdf('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
+  };
+  const fetchChemicalData = async (id: string) => {
+      if (isFetching) return;
+      setIsFetching(true);
+      try {
+          const response = await fetch(`${API_URL}/api/v1/chemicals/${id}`);
+          const data = await response.json();
+          if (response.ok) {
+              setSelectedChemical(data);
+              setModalVisible(true);
+          } else {
+              console.log('Failed to fetch chemical data:', data);
+              Alert.alert('Error', 'Failed to fetch chemical data');
+          }
+      } catch (error) {
+          console.log  ('Error fetching chemical data:', error);
+          Alert.alert('Error', 'nvalid QR or Error fetching chemical data');
+      } finally {
+          setIsFetching(false);
+      }
+  };
+  const closeModal = () => {
+      setScannedData(null); 
+      setModalVisible(false);
+  };
   if (!permission) {
     // Camera permissions are still loading.
     return <View />;
@@ -32,15 +71,26 @@ export default function ViewChemicals() {
 
   return (
     <View style={styles.container}>
-        <CameraView style={styles.camera} facing={facing} onBarcodeScanned={({data}) => {
-        data = data;
-      }}>
+      <CameraView style={styles.camera} facing={facing} onBarcodeScanned={({data}) => {
+          if (!modalVisible && data !== scannedData) {
+              setScannedData(data);
+              fetchChemicalData(data);
+          }
+        }}>
         <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.button} onPress={toggleCameraFacing}>
-            <Text style={styles.text}>Flip Camera</Text>
-          </TouchableOpacity>
+            <TouchableOpacity style={styles.button} onPress={toggleCameraFacing}>
+                <Text style={styles.text}>Flip Camera</Text>
+            </TouchableOpacity>
         </View>
-      </CameraView>
+      </CameraView> 
+
+      <ChemicalDetails
+          selectedChemical={selectedChemical}
+          toggleSDSBottomSheet={toggleSDSBottomSheet}
+          modalVisible={modalVisible}
+          closeModal={closeModal}
+          router={router}
+      />
     </View>
   );
 }


### PR DESCRIPTION
Updated to show the chemical details upon scanning the QR code

- Inner details, when the qr is scanned it returns a number which is the chemical ID, then we do a fetch using that ID and pass that data into chemical details which reflects the chemical details in the modal.

For testing purposes you can find the qrcode at : https://storage.googleapis.com/chemtrack-testing/QRcodes/V4R1GVdfvkGvDj2HIwYv.png (for other sample qr's replace V4R1GVdfvkGvDj2HIwYv with chem ID, the chemical needs to have a qr code generated to show the qr, else 404)
![IMG_028B63F9B139-1](https://github.com/user-attachments/assets/2eab0883-a25c-44a5-a0cc-806b4416f70d)
