### PR TITLE
CT-151 Make sure User is unable to return to App after Logging Out

### DIFF
--- a/frontend/app/(tabs)/profile/profile.tsx
+++ b/frontend/app/(tabs)/profile/profile.tsx
@@ -233,7 +233,7 @@ export default function Profile() {
 
             <Pressable
               style={styles.closePopUpButton}
-              onPress={() => (setConfirmModalVisible(false), router.push('/(auth)/login'))}
+              onPress={() => (setConfirmModalVisible(false), router.replace('/(auth)/login'))}
             >
               <Text style={styles.popUpText}>Yes</Text>
             </Pressable>

--- a/frontend/components/__tests__/ProfilePage.test.tsx
+++ b/frontend/components/__tests__/ProfilePage.test.tsx
@@ -386,7 +386,7 @@ describe('Profile', () => {
         // Simulate button clicks
         fireEvent.press(getByText('Log Out'));
         fireEvent.press(getByText('Yes'));
-        expect(router.push).toHaveBeenCalledWith('/(auth)/login');
+        expect(router.replace).toHaveBeenCalledWith('/(auth)/login');
         // (auth)/login
     });
 

--- a/frontend/components/__tests__/ProfilePage.test.tsx
+++ b/frontend/components/__tests__/ProfilePage.test.tsx
@@ -3,16 +3,9 @@ import {
     Alert,
     Text,
     StyleSheet,
-    Modal,
-    Pressable,
     TouchableOpacity,
 } from 'react-native';
 import CustomButton from '@/components/CustomButton';
-import AddUserIcon from '@/assets/icons/AddUserIcon';
-import BellIcon from '@/assets/icons/BellIcon';
-import EditIcon from '@/assets/icons/EditIcon';
-import ResetIcon from '@/assets/icons/ResetIcon';
-import LoginIcon from '@/assets/icons/LoginIcon';
 import Colors from '@/constants/Colors';
 import Header from '@/components/Header';
 import HeaderTextInput from '@/components/inputFields/HeaderTextInput';
@@ -21,7 +14,6 @@ import { useRouter } from 'expo-router';
 import Profile from '@/app/(tabs)/profile/profile';
 import { useUser } from '@/contexts/UserContext';
 import emailRegex from '@/functions/EmailRegex';
-import CloseIcon from '@/assets/icons/CloseIcon';
 
 import { render, fireEvent, screen, waitFor, getQueriesForElement } from '@testing-library/react-native';
 
@@ -76,10 +68,6 @@ jest.mock('expo-router', () => ({
 
 jest.spyOn(Alert, 'alert');
 
-// Check text function
-function checkText(text: string) {
-    return text;
-}
 
 // Tests
 describe('Profile', () => {
@@ -95,7 +83,6 @@ describe('Profile', () => {
         (useRouter as jest.Mock).mockReturnValue(router);
         jest.spyOn(Alert, 'alert');
         jest.spyOn(global, 'fetch');
-        // Setup PUT API
 
     });
 
@@ -115,8 +102,6 @@ describe('Profile', () => {
         expect(getByText('Name')).toBeTruthy(); // text is part of HeaderInputText, so the user's name would render too technically, could be disable b/c of isEditing variable
         expect(getByText('Email')).toBeTruthy();
         expect(getByText('Update Info')).toBeTruthy();
-        //expect(getByText('Update Info')).toHaveProp('CustomButton', CustomEditIcon);
-        // editicon = function customediticon
         expect(getByText('Notifications')).toBeTruthy();
         expect(getByText('Reset Password')).toBeTruthy();
         expect(getByText('Log Out')).toBeTruthy();
@@ -297,7 +282,6 @@ describe('Profile', () => {
             });
         });
 
-
         // Check if base profile page renders back with new Name and Email
         expect(getByText('My Account')).toBeTruthy();
         expect(getByTestId('avatarFrame')).toBeTruthy();
@@ -387,7 +371,6 @@ describe('Profile', () => {
         fireEvent.press(getByText('Log Out'));
         fireEvent.press(getByText('Yes'));
         expect(router.replace).toHaveBeenCalledWith('/(auth)/login');
-        // (auth)/login
     });
 
     // Logout UI


### PR DESCRIPTION
### Changes

- Made the router replace to overwrite the navigation when user logs out

### Tested Platforms

- IOS 
- Web (Check notes)

### Notes

- Can be tested on IOS by logging out in Profile and then swiping on the Login screen left to right
- On web, for some reason the path history is left with the back arrow, but after clicking them multiple times they disappear.
- Need to be tested on Android