### PR TITLE
CT-149 Connecting the Profile Picture API with the Profile Screen

### DIFF
--- a/backend/controllers/chemical_controllers.go
+++ b/backend/controllers/chemical_controllers.go
@@ -231,7 +231,7 @@ func DeleteChemical(c *gin.Context) {
 	}
 
 	// Delete the QR code from Google Cloud Storage
-	helpers.DeleteFileFromGCS(ctx, "chemtrack-testing", "QRcodes/"+chemicalID+".png")
+	helpers.DeleteFileFromGCS(ctx, "chemtrack-testing2", "QRcodes/"+chemicalID+".png")
 
 	c.JSON(http.StatusOK, gin.H{"message": "Chemical deleted successfully"})
 }

--- a/backend/controllers/file_controllers.go
+++ b/backend/controllers/file_controllers.go
@@ -3,6 +3,7 @@ package controllers
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/ekjyotshinh/ChemTrack/backend/helpers"
 
@@ -306,6 +307,11 @@ func UpdateProfilePicture(c *gin.Context) {
 		return
 	}
 
+	// Append a timestamp to the URL to prevent caching
+	// Ensures image is up to date in the frontend
+	t := time.Now()
+	uploadURL += "?t=" + t.Format("20060102150405")
+
 	// Update Firestore document with the profile picture URL
 	_, err = client.Collection("users").Doc(userID).Update(ctx, []firestore.Update{
 		{Path: "profilePictureURL", Value: uploadURL},
@@ -360,6 +366,7 @@ func DeleteProfilePicture(c *gin.Context) {
 	// Extract the object name from the URL
 	// Example URL: https://storage.googleapis.com/chemtrack-testing/profile_pictures/12345.jpg
 	objectName := profilePictureURLStr[strings.LastIndex(profilePictureURLStr, "profile_pictures/"):]
+	objectName = strings.Split(objectName, "?t=")[0] // Remove the timestamp
 
 	// Delete the file from Google Cloud Storage
 	bucketName := "chemtrack-testing2"

--- a/backend/controllers/file_controllers.go
+++ b/backend/controllers/file_controllers.go
@@ -57,7 +57,7 @@ func AddSDS(c *gin.Context) {
 	defer src.Close()
 
 	// Define GCS bucket and object name
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	objectName := "sds/" + chemID + ".pdf"
 
 	// Upload the file directly from memory
@@ -158,7 +158,7 @@ func DeleteSDS(c *gin.Context) {
 	objectName := sdsURLStr[strings.LastIndex(sdsURLStr, "sds/"):]
 
 	// Delete the file from Google Cloud Storage
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	err = helpers.DeleteFileFromGCS(ctx, bucketName, objectName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete SDS file from GCS"})
@@ -179,7 +179,6 @@ func DeleteSDS(c *gin.Context) {
 		"message": "SDS file deleted successfully",
 	})
 }
-
 
 // AddProfilePicture godoc
 // @Summary Add a new profile picture
@@ -225,7 +224,7 @@ func AddProfilePicture(c *gin.Context) {
 	defer src.Close()
 
 	// Define GCS bucket and object name
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	objectName := "profile_pictures/" + userID + ".jpg"
 
 	// Upload the file directly from memory
@@ -296,7 +295,7 @@ func UpdateProfilePicture(c *gin.Context) {
 	defer src.Close()
 
 	// Define GCS bucket and object name
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	objectName := "profile_pictures/" + userID + ".jpg"
 
 	// Upload the file directly from memory
@@ -363,7 +362,7 @@ func DeleteProfilePicture(c *gin.Context) {
 	objectName := profilePictureURLStr[strings.LastIndex(profilePictureURLStr, "profile_pictures/"):]
 
 	// Delete the file from Google Cloud Storage
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	err = helpers.DeleteFileFromGCS(ctx, bucketName, objectName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to delete profile picture from GCS"})

--- a/backend/controllers/qrcode_controller.go
+++ b/backend/controllers/qrcode_controller.go
@@ -8,10 +8,9 @@ import (
 	//"encoding/json"
 	//"fmt"
 	//"net/http"
-	//"github.com/gin-gonic/gin" 
-	"github.com/skip2/go-qrcode" 
+	//"github.com/gin-gonic/gin"
 	"github.com/ekjyotshinh/ChemTrack/backend/helpers"
-
+	"github.com/skip2/go-qrcode"
 )
 
 // GenerateQRCode generates a QR code for a chemical
@@ -40,7 +39,7 @@ func GenerateQRCode(chemicalIdNumber string) {
 	}
 
 	// Upload the QR code to Google Cloud Storage
-	bucketName := "chemtrack-testing"
+	bucketName := "chemtrack-testing2"
 	objectName := "QRcodes/" + chemID + ".png"
 
 	err = helpers.UploadFileToGCS(ctx, bucketName, objectName, filepath)

--- a/backend/routes/file_routes.go
+++ b/backend/routes/file_routes.go
@@ -1,8 +1,8 @@
 package routes
 
 import (
-	"github.com/gin-gonic/gin"
 	"github.com/ekjyotshinh/ChemTrack/backend/controllers"
+	"github.com/gin-gonic/gin"
 )
 
 // RegisterRoutes defines and registers all routes
@@ -10,14 +10,14 @@ func RegisterRoutesFiles(router *gin.Engine) {
 	r := router.Group("/api/v1")
 
 	// sds routes
-	r.POST("/files/sds/:chemicalIdNumber", controllers.AddSDS)  	// Create a new chemical
-	r.GET("/files/sds/:chemicalIdNumber", controllers.GetSDS)   // Retrieve SDS URL
+	r.POST("/files/sds/:chemicalIdNumber", controllers.AddSDS)      // Create a new chemical
+	r.GET("/files/sds/:chemicalIdNumber", controllers.GetSDS)       // Retrieve SDS URL
 	r.DELETE("/files/sds/:chemicalIdNumber", controllers.DeleteSDS) // Delete SDS
 
 	//profile picture routes
+	r.POST("/files/profile/:userId", controllers.AddProfilePicture)      // Add a new profile picture
+	r.GET("/files/profile/:userId", controllers.GetProfilePicture)       // Get the profile picture URL
+	r.DELETE("/files/profile/:userId", controllers.DeleteProfilePicture) // Delete profile picture
+	r.PUT("/files/profile/:userId", controllers.UpdateProfilePicture)    // Update existing profile picture
 
-	r.POST("/files/profile/:userId", controllers.AddProfilePicture)  	// Create a new chemical
-	r.GET("/files/profile/:userId", controllers.GetProfilePicture)   // Retrieve SDS URL
-	r.DELETE("/files/profile/:userId", controllers.DeleteProfilePicture) // Delete SDS
-	
 }

--- a/frontend/app.json
+++ b/frontend/app.json
@@ -79,6 +79,12 @@
           "icon": "./assets/images/icon.png",
           "color": "#ffffff"
         }
+      ],
+      [
+        "expo-image-picker",
+        {
+          "photosPermission": "Allow $(PRODUCT_NAME) to access your photos"
+        }
       ]  
     ],  
     "experiments": {

--- a/frontend/app/(tabs)/profile/profile.tsx
+++ b/frontend/app/(tabs)/profile/profile.tsx
@@ -104,11 +104,11 @@ export default function Profile() {
     setIsEditing(false);
   }
 
-  // TODO: Fetch image from the backend initially (useEffect)
+  // TODO: Fetch image from the backend initially (useEffect) (GET Request)
   const [image, setImage] = useState<string | null>(null);
 
-  // Pick image for the profile picture
-  const pickImage = async () => {
+  // Pick user's profile picture
+  const handlePickImage = async () => {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       allowsEditing: true,
@@ -119,8 +119,41 @@ export default function Profile() {
     if (!result.canceled && result) {
       setImage(result.assets[0].uri);
     }
+  }
 
-    // TODO: Need to save to backend
+  // Delete user's profile picture
+  const handleDeleteImage = async () => {
+    setImage(null);
+  }
+
+  // Open an alert to delete or replace profile picture
+  const onEditImage = async () => {
+    if (image) {
+      Alert.alert(
+        'Edit Profile Picture',
+        'Deleting changes the image back to displaying your initials',
+        [
+          {
+            text: 'Cancel',
+            style: 'cancel',
+          },
+          {
+            // Use PUT request for updating
+            // so check if the user has a pfp first in handlePickImage
+            text: 'Edit',
+            onPress: handlePickImage,
+          },
+          {
+            // Use DELETE request
+            text: 'Delete',
+            onPress: handleDeleteImage,
+          },
+        ]
+      );
+    } else {
+      // Use POST request for adding for the first time
+      await handlePickImage();
+    }
   }
 
   return (
@@ -134,7 +167,7 @@ export default function Profile() {
           <View style={styles.avatarContainer}>
             {image ? 
               <Image source={{ uri: image }} style={styles.avatarImage} /> : 
-              
+
               <View style={[styles.avatarImage, styles.avatarTextImage]} testID='avatarFrame'>
                 <TextInter
                   style={styles.avatarText}
@@ -148,7 +181,7 @@ export default function Profile() {
           {/* Name and Email Inputs */}
           <View>
             <TouchableOpacity
-              onPress={pickImage}
+              onPress={onEditImage}
               testID='editButton'>
               <Text style={styles.editText}>
                 {'Edit'}

--- a/frontend/app/(tabs)/profile/profile.tsx
+++ b/frontend/app/(tabs)/profile/profile.tsx
@@ -34,7 +34,6 @@ export default function Profile() {
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
 
   const [imageURI, setImageURI] = useState<string | null>(null);
-  const [rerender, setRerender] = useState(false);
 
   const [isValidEmail, setIsValidEmail] = useState(false);
   emailRegex({ email, setIsValidEmail });
@@ -139,7 +138,7 @@ export default function Profile() {
       quality: 1.0,
     });
 
-    if (!result.canceled && result) {
+    if (result && !result.canceled) {
       let formData = new FormData();
 
       // Add the image to the form data, which will get sent to backend

--- a/frontend/app/(tabs)/profile/profile.tsx
+++ b/frontend/app/(tabs)/profile/profile.tsx
@@ -33,6 +33,9 @@ export default function Profile() {
   const [isEditing, setIsEditing] = useState(false);
   const [confirmModalVisible, setConfirmModalVisible] = useState(false);
 
+  const [imageURI, setImageURI] = useState<string | null>(null);
+  const [rerender, setRerender] = useState(false);
+
   const [isValidEmail, setIsValidEmail] = useState(false);
   emailRegex({ email, setIsValidEmail });
 
@@ -40,11 +43,32 @@ export default function Profile() {
   const { userInfo, updateUserInfo } = useUser();
   const API_URL = `http://${process.env.EXPO_PUBLIC_API_URL}`;
 
+  // Get profile picture from backend
+  const fetchAvatarImage = async () => {
+    try {
+      const response = await fetch(`${API_URL}/api/v1/files/profile/${userInfo.id}`, {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch user\'s profile picture');
+      }
+
+      const data = await response.json();
+      setImageURI(data.profilePictureURL);
+
+    } catch (error) {
+      console.log('Failed to fetch user\'s profile picture');
+    }
+  }
+
   // Initialize name and email from user info
   useEffect(() => {
     if (userInfo) {
       setName(userInfo.name);
       setEmail(userInfo.email);
+      fetchAvatarImage();
     }
   }, [userInfo]);
 
@@ -104,11 +128,10 @@ export default function Profile() {
     setIsEditing(false);
   }
 
-  // TODO: Fetch image from the backend initially (useEffect) (GET Request)
-  const [image, setImage] = useState<string | null>(null);
-
   // Pick user's profile picture
   const handlePickImage = async () => {
+
+    // Get image from user's device
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ['images'],
       allowsEditing: true,
@@ -117,18 +140,58 @@ export default function Profile() {
     });
 
     if (!result.canceled && result) {
-      setImage(result.assets[0].uri);
+      let formData = new FormData();
+
+      // Add the image to the form data, which will get sent to backend
+      formData.append('profilePicture', {
+        uri: result.assets[0].uri,
+        name: 'profile.jpg',
+        type: 'image/jpeg',
+      } as any);
+
+      try {
+        // Use PUT request for updating and if profile picture already exists
+        // Use POST request for adding if profile picture doesn't exist
+        const response = await fetch(`${API_URL}/api/v1/files/profile/${userInfo.id}`, {
+          method: imageURI ? 'PUT' : 'POST',
+          body: formData,
+        });
+
+        const data = await response.json();
+
+        if (!response.ok) {
+          throw new Error('Failed to update profile picture');
+        } else {
+          setImageURI(data.url);
+        }
+
+      } catch (error) {
+        Alert.alert('Error', 'Failed to update profile picture');
+      }
     }
   }
 
   // Delete user's profile picture
   const handleDeleteImage = async () => {
-    setImage(null);
+    try {
+      const response = await fetch(`${API_URL}/api/v1/files/profile/${userInfo.id}`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+      if (!response.ok) throw new Error('Failed to delete profile picture');
+
+    } catch (error) {
+      Alert.alert('Error', 'Failed to delete profile picture.');
+      console.error(error);
+    }
+
+    setImageURI(null);
   }
 
   // Open an alert to delete or replace profile picture
   const onEditImage = async () => {
-    if (image) {
+    if (imageURI) {
       Alert.alert(
         'Edit Profile Picture',
         'Deleting changes the image back to displaying your initials',
@@ -164,9 +227,9 @@ export default function Profile() {
         <View style={{ marginTop: Size.height(136), alignItems: 'center' }}>
 
           {/* Avatar Section */}
-          <View style={styles.avatarContainer}>
-            {image ? 
-              <Image source={{ uri: image }} style={styles.avatarImage} /> : 
+          <TouchableOpacity style={styles.avatarContainer} onPress={onEditImage}>
+            {imageURI ?
+              <Image source={{ uri: imageURI }} style={styles.avatarImage} /> :
 
               <View style={[styles.avatarImage, styles.avatarTextImage]} testID='avatarFrame'>
                 <TextInter
@@ -176,7 +239,7 @@ export default function Profile() {
                   {userInfo?.name ? getInitials(userInfo.name) : ''}
                 </TextInter>
               </View>}
-          </View>
+          </TouchableOpacity>
 
           {/* Name and Email Inputs */}
           <View>

--- a/frontend/app/(tabs)/profile/profile.tsx
+++ b/frontend/app/(tabs)/profile/profile.tsx
@@ -8,6 +8,7 @@ import {
   Modal,
   Pressable,
   TouchableOpacity,
+  Image,
 } from 'react-native';
 import CustomButton from '@/components/CustomButton';
 import AddUserIcon from '@/assets/icons/AddUserIcon';
@@ -24,6 +25,7 @@ import { useRouter } from 'expo-router';
 import { useUser } from '@/contexts/UserContext';
 import emailRegex from '@/functions/EmailRegex';
 import CloseIcon from '@/assets/icons/CloseIcon';
+import * as ImagePicker from 'expo-image-picker';
 
 export default function Profile() {
   const [name, setName] = useState('');
@@ -102,31 +104,54 @@ export default function Profile() {
     setIsEditing(false);
   }
 
+  // TODO: Fetch image from the backend initially (useEffect)
+  const [image, setImage] = useState<string | null>(null);
+
+  // Pick image for the profile picture
+  const pickImage = async () => {
+    const result = await ImagePicker.launchImageLibraryAsync({
+      mediaTypes: ['images'],
+      allowsEditing: true,
+      aspect: [1, 1],
+      quality: 1.0,
+    });
+
+    if (!result.canceled && result) {
+      setImage(result.assets[0].uri);
+    }
+
+    // TODO: Need to save to backend
+  }
+
   return (
     <View style={styles.container}>
       <Header headerText="My Account" />
 
       <ScrollView style={styles.scrollContainer}>
         <View style={{ marginTop: Size.height(136), alignItems: 'center' }}>
+
           {/* Avatar Section */}
           <View style={styles.avatarContainer}>
-            <View style={styles.avatarImage} testID='avatarFrame'>
-              <TextInter
-                style={styles.avatarText}
-                testID='initialsInput'
-              >
-                {userInfo?.name ? getInitials(userInfo.name) : ''}
-              </TextInter>
-            </View>
+            {image ? 
+              <Image source={{ uri: image }} style={styles.avatarImage} /> : 
+              
+              <View style={[styles.avatarImage, styles.avatarTextImage]} testID='avatarFrame'>
+                <TextInter
+                  style={styles.avatarText}
+                  testID='initialsInput'
+                >
+                  {userInfo?.name ? getInitials(userInfo.name) : ''}
+                </TextInter>
+              </View>}
           </View>
 
           {/* Name and Email Inputs */}
           <View>
             <TouchableOpacity
-              onPress={isEditing ? handleCancel : () => setIsEditing(true)}
+              onPress={pickImage}
               testID='editButton'>
               <Text style={styles.editText}>
-                {isEditing ? 'Cancel Edit' : 'Edit'}
+                {'Edit'}
               </Text>
             </TouchableOpacity>
           </View>
@@ -269,20 +294,21 @@ const styles = StyleSheet.create({
     width: Size.width(132),
     height: Size.width(132),
     borderRadius: 100,
-    backgroundColor: Colors.white,
-    justifyContent: 'center',
-    alignItems: 'center',
     margin: 5,
     shadowColor: Colors.grey,
     shadowOpacity: 0.5,
     shadowOffset: { height: 1, width: 0.2 },
     elevation: 2,
   },
+  avatarTextImage: {
+    backgroundColor: Colors.white,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
   avatarText: {
     fontSize: 45,
     fontWeight: 'bold',
     textAlign: 'center',
-    backgroundColor: Colors.white,
   },
   editText: {
     color: Colors.blue,

--- a/frontend/components/__tests__/ProfilePage.test.tsx
+++ b/frontend/components/__tests__/ProfilePage.test.tsx
@@ -1,21 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import {
-    Alert,
-    Text,
-    StyleSheet,
-    TouchableOpacity,
-} from 'react-native';
-import CustomButton from '@/components/CustomButton';
-import Colors from '@/constants/Colors';
-import Header from '@/components/Header';
-import HeaderTextInput from '@/components/inputFields/HeaderTextInput';
-import Size from '@/constants/Size';
+import { Alert } from 'react-native';
 import { useRouter } from 'expo-router';
 import Profile from '@/app/(tabs)/profile/profile';
 import { useUser } from '@/contexts/UserContext';
-import emailRegex from '@/functions/EmailRegex';
-
-import { render, fireEvent, screen, waitFor, getQueriesForElement } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 
 
 // Mock Placeholder setup for User information and Routing
@@ -129,46 +116,22 @@ describe('Profile', () => {
     });
 
 
-    // Edit Page: Simulate Edit button click and Update Info button for User
-    test('User Edit Info Page Renders with Blue Edit and Update Info Buttons', () => {
+    // Edit Page: Simulate Update Info button for User
+    test('User Edit Info Page Renders with Update Info Button', () => {
         // Render User
         (useUser as jest.Mock).mockReturnValue({ userInfo: mockUser })
 
         const { getByText, getByTestId } = render(<Profile />);
-        // Simulate Edit Text being clicked
-        fireEvent.press(getByText('Edit'));
-        // Confirm page changed
-        expect(getByTestId('editButton')).toHaveTextContent('Cancel Edit'); // The blue Edit text
-        expect(getByText('Finish Updating')).toBeTruthy();
-        let updateText = screen.getAllByText('Cancel Edit')[1]; // Check the 2nd 'Cancel Edit' text in the custom button
-        expect(updateText).toBeTruthy;
-
-        // Revert to based page by clicking Edit text again
-        fireEvent.press(getByTestId('editButton')); // Get the blue text 
-
-        // Check if base profile page renders back
-        expect(getByText('My Account')).toBeTruthy();
-        expect(getByTestId('initialsInput')).toBeTruthy();
-        expect(getByText('Edit')).toBeTruthy();
-        expect(getByText('Name')).toBeTruthy();
-        expect(getByText('Email')).toBeTruthy();
-        expect(getByText('Update Info')).toBeTruthy();
-        expect(getByText('Notifications')).toBeTruthy();
-        expect(getByText('Reset Password')).toBeTruthy();
-        expect(getByText('Log Out')).toBeTruthy();
-
 
         // Check the Update Info button
         // Simulate Update Info button being clicked
         fireEvent.press(getByText('Update Info'));
         // Confirm page changed
-        expect(getByTestId('editButton')).toHaveTextContent('Cancel Edit'); // The blue Edit text
         expect(getByText('Finish Updating')).toBeTruthy();
-        let updateText2 = screen.getAllByText('Cancel Edit')[1]; // Check the 2nd 'Cancel Edit' text in the custom button
-        expect(updateText2).toBeTruthy;
+        expect(getByText('Cancel Edit')).toBeTruthy();
 
-        // Revert to based page by clicking Edit text again
-        fireEvent.press(updateText2); // Click the Cancel Edit button 
+        // Revert to based page by clicking Cancel Edit
+        fireEvent.press(getByText('Cancel Edit')); // Click the Cancel Edit button 
 
         // Check if base profile page renders back
         expect(getByText('My Account')).toBeTruthy();
@@ -184,45 +147,21 @@ describe('Profile', () => {
     });
 
     // Edit Page: Simulate Edit button click and Update Info button for Master
-    test('Master Edit Info Page Renders with Blue Edit Text', () => {
+    test('Master User Edit Info Page Renders with Update Info Button', () => {
         // Render User
         (useUser as jest.Mock).mockReturnValue({ userInfo: mockMaster });
 
         const { getByText, getByTestId } = render(<Profile />);
-        // Simulate Edit Text being clicked
-        fireEvent.press(getByText('Edit'));
-        // Confirm page changed
-        expect(getByTestId('editButton')).toHaveTextContent('Cancel Edit');
-        expect(getByText('Finish Updating')).toBeTruthy();
-        let updateText = screen.getAllByText('Cancel Edit')[1]; // Get the 2nd 'Cancel Edit' text in the custom button
-        expect(updateText).toBeTruthy;
-
-        // Revert to based page by clicking Edit text again
-        fireEvent.press(getByTestId('editButton')); // Get the blue text 
-
-        // Check if base profile page renders back
-        expect(getByText('My Account')).toBeTruthy();
-        expect(getByTestId('initialsInput')).toBeTruthy();
-        expect(getByText('Edit')).toBeTruthy();
-        expect(getByText('Name')).toBeTruthy();
-        expect(getByText('Email')).toBeTruthy();
-        expect(getByText('Update Info')).toBeTruthy();
-        expect(getByText('Invite User')).toBeTruthy();
-        expect(getByText('Notifications')).toBeTruthy();
-        expect(getByText('Reset Password')).toBeTruthy();
-        expect(getByText('Log Out')).toBeTruthy();
 
         // Check the Update Info button
         // Simulate Update Info button being clicked
         fireEvent.press(getByText('Update Info'));
         // Confirm page changed
-        expect(getByTestId('editButton')).toHaveTextContent('Cancel Edit'); // The blue Edit text
         expect(getByText('Finish Updating')).toBeTruthy();
-        let updateText2 = screen.getAllByText('Cancel Edit')[1]; // Check the 2nd 'Cancel Edit' text in the custom button
-        expect(updateText2).toBeTruthy;
+        expect(getByText('Cancel Edit')).toBeTruthy();
 
-        // Revert to based page by clicking Edit text again
-        fireEvent.press(updateText2); // Click the Cancel Edit button 
+        // Revert to based page by clicking Cancel Edit
+        fireEvent.press(getByText('Cancel Edit')); // Click the Cancel Edit button 
 
         // Check if base profile page renders back
         expect(getByText('My Account')).toBeTruthy();

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -23,6 +23,7 @@
         "expo-file-system": "^18.0.11",
         "expo-font": "~13.0.3",
         "expo-google-fonts": "^0.0.0",
+        "expo-image-picker": "~16.0.6",
         "expo-linking": "~7.0.5",
         "expo-media-library": "^17.0.6",
         "expo-modules-core": "^2.2.2",
@@ -8535,6 +8536,27 @@
       "resolved": "https://registry.npmjs.org/expo-google-fonts/-/expo-google-fonts-0.0.0.tgz",
       "integrity": "sha512-SpY1N5ZHGbNXuvN8s3E2HxjlcxR5NHWn72Uy8wl0uZJ0ueWd+JfTUXwZzfuF638WeTdgJKztRy2MWfuMORQ1yQ==",
       "license": "MIT"
+    },
+    "node_modules/expo-image-loader": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-5.0.0.tgz",
+      "integrity": "sha512-Eg+5FHtyzv3Jjw9dHwu2pWy4xjf8fu3V0Asyy42kO+t/FbvW/vjUixpTjPtgKQLQh+2/9Nk4JjFDV6FwCnF2ZA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "16.0.6",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-16.0.6.tgz",
+      "integrity": "sha512-HN4xZirFjsFDIsWFb12AZh19fRzuvZjj2ll17cGr19VNRP06S/VPQU3Tdccn5vwUzQhOBlLu704CnNm278boiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~5.0.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
     },
     "node_modules/expo-keep-awake": {
       "version": "14.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -50,7 +50,8 @@
     "react-native-screens": "~4.4.0",
     "react-native-svg": "^15.8.0",
     "react-native-web": "~0.19.13",
-    "react-native-webview": "13.12.5"
+    "react-native-webview": "13.12.5",
+    "expo-image-picker": "~16.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
# Connect Profile Picture Backend API to Frontend

### Changes
- Clicking the edit button or the profile picture image allows user to pick a profile picture
- If the user already has a profile picture uploaded, it opens an alert pop up giving them options to either delete or edit the image
- Added timestamps to the backend URL whenever the image is updating, which ensures the most up-to-date image shown to the user
- Removed tests related to the edit button since its function is no longer to edit user information
- Also updated the backend to use chemtrack-testing2 for bucket names since we have an updated account

### Testing
- Tested on an Android emulator and iOS device

### Notes
- Tried adding tests but don't know how to change a useState value (imageURI, setImageURI) that's inside the code in Jest and the popup that allows users to choose photos from their gallery does not appear when debugging, so I've decided to not add tests
- Also, console errors/warnings show up for Jest due to the fetch request being made for the profile picture, but all the tests pass and seem to work

### Demo
<img src="https://github.com/user-attachments/assets/26401cba-f1f9-42aa-9a3a-958c612ebce0" height="600" />
