### PR TITLE
Proper router pushing when scanning QR code to SDS sheet

### DIFF
--- a/frontend/app/(tabs)/scanQRCode.tsx
+++ b/frontend/app/(tabs)/scanQRCode.tsx
@@ -12,6 +12,7 @@ export default function ViewChemicals() {
   const [scannedData, setScannedData] = useState<string | null>(null);
   const [selectedChemical, setSelectedChemical] = useState(null);
   const [modalVisible, setModalVisible] = useState(false);
+  const [sdsUrl, setSdsUrl] = useState('');
   const [isSDSBottomSheetOpen, setIsSDSBottomSheetOpen] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const router = useRouter();
@@ -32,14 +33,7 @@ export default function ViewChemicals() {
   };
   const toggleSDSBottomSheet = () => {
     setIsSDSBottomSheetOpen(!isSDSBottomSheetOpen);
-    try {
-      let sdsUrl: string = selectedChemical.sdsURL;
-      viewPdf(sdsUrl);
-    }
-    catch (error) {
-      console.error(error);
-      Alert.alert('Error', 'Error occured');
-    }
+    viewPdf(sdsUrl);
   };
   const fetchChemicalData = async (id: string) => {
     if (isFetching) return;
@@ -50,6 +44,7 @@ export default function ViewChemicals() {
       if (response.ok) {
         setSelectedChemical(data);
         setModalVisible(true);
+        setSdsUrl(data.sdsURL);
       } else {
         console.log('Failed to fetch chemical data:', data);
         Alert.alert('Error', 'Failed to fetch chemical data');

--- a/frontend/app/(tabs)/scanQRCode.tsx
+++ b/frontend/app/(tabs)/scanQRCode.tsx
@@ -18,13 +18,22 @@ export default function ViewChemicals() {
   const API_URL = `http://${process.env.EXPO_PUBLIC_API_URL}`;
   const viewPdf = async (pdfUrl: string) => {
     console.log('Opening PDF:', pdfUrl);
-    await WebBrowser.openBrowserAsync(pdfUrl);
+    try {
+      router.push({
+        pathname: '/fileViewer',
+        params: { pdfUrl }
+      });
+    }
+    // For other errors besides responses
+    catch (error) {
+      console.error(error);
+      Alert.alert('Error', 'Error occured');
+    };
   };
   const toggleSDSBottomSheet = () => {
     setIsSDSBottomSheetOpen(!isSDSBottomSheetOpen);
     try {
       let sdsUrl: string = selectedChemical.sdsURL;
-      //viewPdf('https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf');
       viewPdf(sdsUrl);
     }
     catch (error) {

--- a/frontend/components/viewChemicalModals/ChemicalDetails.tsx
+++ b/frontend/components/viewChemicalModals/ChemicalDetails.tsx
@@ -13,7 +13,7 @@ import { useRouter } from 'expo-router';
 import { useUser } from '@/contexts/UserContext';
 import downloadFile from '../../functions/downloadFile';
 
-
+const API_URL = `http://${process.env.EXPO_PUBLIC_API_URL}`;
 interface chemicalDetailProps {
     property: string
     value: string | null
@@ -120,7 +120,7 @@ const ChemicalDetails = ({ selectedChemical, toggleSDSBottomSheet, modalVisible,
 
                     {/* Status & Quantity */}
                     <ChemicalDetail property={'Status: '} value={selectedChemical.status} color={getStatusColor(selectedChemical.status)} />
-                    <ChemicalDetail property={'Quantity: '} value={selectedChemical.quantity}  margin={gapSize} />
+                    <ChemicalDetail property={'Quantity: '} value={selectedChemical.quantity} margin={gapSize} />
 
                     {/* Buttons */}
                     <View style={stylesPopup.buttonContainer}>
@@ -139,10 +139,10 @@ const ChemicalDetails = ({ selectedChemical, toggleSDSBottomSheet, modalVisible,
                             icon={<ViewDocIcon color={Colors.black} />}
                             textColor={Colors.black}
                             onPress={() => {
-                            closeModal();  // Close the modal
+                                closeModal();  // Close the modal
                                 router.push({
-                                pathname: '/fileViewer', 
-                                params: {  fileUrl:'https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf', title: selectedChemical.name } 
+                                    pathname: '/fileViewer',
+                                    params: { fileUrl: `${API_URL}/api/v1/files/sds/${selectedChemical.id}`, title: selectedChemical.name }
                                 });
                             }}
                             color={Colors.white}

--- a/frontend/components/viewChemicalModals/ChemicalDetails.tsx
+++ b/frontend/components/viewChemicalModals/ChemicalDetails.tsx
@@ -13,7 +13,6 @@ import { useRouter } from 'expo-router';
 import { useUser } from '@/contexts/UserContext';
 import downloadFile from '../../functions/downloadFile';
 
-const API_URL = `http://${process.env.EXPO_PUBLIC_API_URL}`;
 interface chemicalDetailProps {
     property: string
     value: string | null
@@ -142,7 +141,7 @@ const ChemicalDetails = ({ selectedChemical, toggleSDSBottomSheet, modalVisible,
                                 closeModal();  // Close the modal
                                 router.push({
                                     pathname: '/fileViewer',
-                                    params: { fileUrl: `${API_URL}/api/v1/files/sds/${selectedChemical.id}`, title: selectedChemical.name }
+                                    params: { fileUrl: `https://storage.googleapis.com/chemtrack-testing2/sds/${selectedChemical.id}.pdf`, title: selectedChemical.name }
                                 });
                             }}
                             color={Colors.white}


### PR DESCRIPTION
From the selecting the Scan QR Code button, user scans QR Code, selects View SDS, and now the user will properly be moved to view the PDF accordingly.